### PR TITLE
Updating recursion_limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::upper_case_acronyms)]
-#![recursion_limit = "256"]
+#![recursion_limit = "1024"]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 


### PR DESCRIPTION
### Raising the recursion limit because of an error: `error: reached the recursion limit while instantiating <from_generator::GenFuture<[stat...on>}]> as futures::Future>::poll`
